### PR TITLE
added installation instructions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,23 @@ The Java OCS library is an introductory language-specific examples of programmin
 
 The library is not intended to show every endpoint and every option/parameter for endpoints it has. The library is known to be incomplete.
 
-Other language libraries and samples are available on [Github](https://github.com/osisoft/OSI-Samples).
+### To install the library locally:
+1. Clone a local copy of the GitHub repository.
+1. Download `apache-maven-x.x.x.zip` from [http://maven.apache.org](http://maven.apache.org) and extract it.
+1. Setting environment variables.
+   1. For Java JDK  
+      1. New User Variable
+          1. Variable name - `JAVA_HOME`  
+          1. Variable value - location to the Java JDK in User variables.
+      1. add JDK\bin path to the Path variable in System variables.
+   1. For Maven  
+      1. New User Variable
+          1. Variable name - `MAVEN_HOME`  
+          1. Variable value - location to the extracted folder for the maven `~\apache-maven-x.x.x` in User variables.
+      1. add `~\apache-maven-x.x.x\bin` path to the Path variable in System variables.
+1. \*Install the ocs_sample_library_preview to your local Maven repo using `mvn install` from `/sample-ocs-sample_libraries-java`
 
-To install these locally run:
-`mvn install`
+\*Currently this project is not hosted on the central Maven repo and must be compiled and installed locally.
 
 Tests are done by testing the sample apps that use this
 
@@ -19,6 +32,7 @@ Developed against Maven 3.6.1 and Java 1.8.0_181.
 
 [OSI Samples](https://github.com/osisoft/OSI-samples) are licensed under the Apache 2 license.
 
+---
 For the main OCS sample libraries page on master [ReadMe](https://github.com/osisoft/OSI-Samples-OCS/blob/master/docs/SAMPLE_LIBRARIES_README.md)  
 For the main OCS samples page on master [ReadMe](https://github.com/osisoft/OSI-Samples-OCS)  
 For the main OSIsoft samples page on master [ReadMe](https://github.com/osisoft/OSI-Samples)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ The Java OCS library is an introductory language-specific examples of programmin
 
 The library is not intended to show every endpoint and every option/parameter for endpoints it has. The library is known to be incomplete.
 
-### To install the library locally:
+## Installing the Library Locally
+
+### Using Eclipse:
+
+1. Clone a local copy of the GitHub repository.
+1. In Eclipse, select `File` > `Import` > `Maven`> `Existing maven project` 
+1. Select the local copy, and click Finish to add it to your workspace
+
+### Using Command Line:
+
 1. Clone a local copy of the GitHub repository.
 1. Download `apache-maven-x.x.x.zip` from [http://maven.apache.org](http://maven.apache.org) and extract it.
 1. Setting environment variables.
@@ -26,7 +35,7 @@ The library is not intended to show every endpoint and every option/parameter fo
 
 \*Currently this project is not hosted on the central Maven repo and must be compiled and installed locally.
 
-Tests are done by testing the sample apps that use this
+Tests are done by testing the sample apps that use this library.
 
 Developed against Maven 3.6.1 and Java 1.8.0_181.
 


### PR DESCRIPTION
these instructions used to be on the individual sample readmes, but for manageability they should be moved to this readme and linked