### PR TITLE
Add Missing getWindowValues Overload

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.1.9-preview / 2022-01-15
+
+- Fix missing getWindowValues overload
+
 ## 0.1.8-preview / 2022-01-15
 
 - Add support for OCS communities

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSIsoft Cloud Services Java Library Sample
 
-**Version:** 0.1.8-preview
+**Version:** 0.1.9-preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-sample_libraries-java?repoName=osisoft%2Fsample-ocs-sample_libraries-java&branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2621&repoName=osisoft%2Fsample-ocs-sample_libraries-java&branchName=main)
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.osisoft.ocs_sample_library_preview</groupId>
   <artifactId>ocs_sample_library_preview</artifactId>
-  <version>0.1.8-preview</version>
+  <version>0.1.9-preview</version>
 
   <name>ocs_sample_library_preview</name>
   <description>A preview of an OCS (OSIsoft Cloud Services) client library</description>

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/sds/StreamsClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/sds/StreamsClient.java
@@ -987,6 +987,25 @@ public class StreamsClient {
         return getWindowValues(tenantId, namespaceId, streamId, startIndex, endIndex, filter, "", baseClient.getHttpHeadersForRequest());
     }
 
+    
+    /**
+     * gets window value of stream
+     * 
+     * @param tenantId    tenant to work against
+     * @param namespaceId namespace to work against
+     * @param streamId    stream to get window value from
+     * @param startIndex  starting index
+     * @param endIndex    ending index
+     * @param filter      filter to reduce the number of values returned
+     * @param form        use this to specify the format of the returned payload
+     * @return string of values
+     * @throws SdsError any error that occurs
+     */
+    public String getWindowValues(String tenantId, String namespaceId, String streamId, String startIndex,
+            String endIndex, String filter, String form) throws SdsError {
+        return getWindowValues(tenantId, namespaceId, streamId, startIndex, endIndex, filter, form, baseClient.getHttpHeadersForRequest());
+    }
+
     /**
      * gets window value of stream
      * 

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/sds/StreamsClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/sds/StreamsClient.java
@@ -987,7 +987,6 @@ public class StreamsClient {
         return getWindowValues(tenantId, namespaceId, streamId, startIndex, endIndex, filter, "", baseClient.getHttpHeadersForRequest());
     }
 
-    
     /**
      * gets window value of stream
      * 


### PR DESCRIPTION
Adding an overload for getWindowValues where both filter and form are specified that doesn't require a header collection.